### PR TITLE
Fix build error on GCC 13

### DIFF
--- a/instructionAPI/src/InstructionDecoder-aarch64.h
+++ b/instructionAPI/src/InstructionDecoder-aarch64.h
@@ -33,6 +33,11 @@
 #include "Immediate.h"
 #include "dyn_regs.h"
 
+#include <array>
+#include <iostream>
+#include <stdint.h>
+#include <string>
+
 namespace Dyninst
 {
 namespace InstructionAPI

--- a/instructionAPI/src/InstructionDecoder-amdgpu-vega.h
+++ b/instructionAPI/src/InstructionDecoder-amdgpu-vega.h
@@ -33,6 +33,11 @@
 #include "Immediate.h"
 #include "dyn_regs.h"
 
+#include <array>
+#include <iostream>
+#include <stdint.h>
+#include <string>
+
 namespace Dyninst
 {
 namespace InstructionAPI


### PR DESCRIPTION
Missing `#include <array>`