### PR TITLE
Cherry pick proccontrol changes to fix runtime-instrumentation involving OpenMP programs

### DIFF
--- a/dyninstAPI/src/dynProcess.C
+++ b/dyninstAPI/src/dynProcess.C
@@ -1063,8 +1063,10 @@ PCProcess::insertBreakpointAtMain()
     }
     Address addr = main_function_->addr();
 
-    // Create the breakpoint
-    mainBrkPt_ = Breakpoint::newBreakpoint();
+    // Libraries loaded before reaching 'main' can launch threads, so
+    // ensure they are all stopped before "executing" this breakpoint.
+    mainBrkPt_ = Breakpoint::newSynchronousBreakpoint();
+
     if(!pcProc_->addBreakpoint(addr, mainBrkPt_))
     {
         startup_printf("%s[%d]: failed to insert a breakpoint at main entry: 0x%lx\n",

--- a/proccontrol/h/PCProcess.h
+++ b/proccontrol/h/PCProcess.h
@@ -130,6 +130,7 @@ public:
     static Breakpoint::ptr newTransferBreakpoint(Dyninst::Address to);
     static Breakpoint::ptr newTransferOffsetBreakpoint(signed long shift);
     static Breakpoint::ptr newHardwareBreakpoint(unsigned int mode, unsigned int size);
+    static Breakpoint::ptr newSynchronousBreakpoint();
 
     void* getData() const;
     void  setData(void* p) const;
@@ -139,6 +140,8 @@ public:
 
     void setSuppressCallbacks(bool);
     bool suppressCallbacks() const;
+
+    bool isSynchronous() const;
 };
 
 class PC_EXPORT Library

--- a/proccontrol/src/event.C
+++ b/proccontrol/src/event.C
@@ -560,6 +560,19 @@ Thread::const_ptr
 EventNewLWP::getNewThread() const
 {
     int_thread* thr = getProcess()->llproc()->threadPool()->findThreadByLWP(lwp);
+
+#if defined(os_linux) || defined(os_freebsd)
+    if(!thr)
+    {
+        int pid = getProcess()->llproc()->getPid();
+        if(lwp != pid)
+        {
+            pthrd_printf("Non-main thread %d/%d not found\n", pid, lwp);
+            return Thread::const_ptr();
+        }
+    }
+#endif
+
     assert(thr);
     return thr->thread();
 }

--- a/proccontrol/src/handler.C
+++ b/proccontrol/src/handler.C
@@ -1564,7 +1564,24 @@ HandleBreakpoint::handleEvent(Event::ptr ev)
     if(!int_ebp->cb_bps.empty() && !ebp->suppressCB())
     {
         pthrd_printf("BP handler is setting user state to reflect breakpoint\n");
-        switch(ebp->getSyncType())
+
+        const Event::SyncType effective_sync_type = [&ebp, &hl_bps]() {
+            /**
+             * A synchronous breakpoint requires all threads in the process to be
+             * stopped before it is "executed".
+             **/
+            for(auto&& bp : hl_bps)
+            {
+                if(bp->isSynchronous())
+                {
+                    pthrd_printf("Found synchronous breakpoint, upgrading to sync_process\n");
+                    return Event::sync_process;
+                }
+            }
+            return ebp->getSyncType();
+        }();
+
+        switch(effective_sync_type)
         {
             case Event::sync_process: {
                 int_threadPool* pool = proc->threadPool();

--- a/proccontrol/src/int_process.h
+++ b/proccontrol/src/int_process.h
@@ -1345,6 +1345,10 @@ private:
     bool                        procstopper;
     bool                        suppress_callbacks;
     bool                        offset_transfer;
+
+    // all threads in process need to be synchronized at this breakpoint
+    bool is_proc_synchronous{false};
+
     std::set<Thread::const_ptr> thread_specific;
 
 public:
@@ -1372,6 +1376,9 @@ public:
 
     void setSuppressCallbacks(bool);
     bool suppressCallbacks(void) const;
+
+    void makeSynchronous() { is_proc_synchronous = true; }
+    bool isSynchronous() const { return is_proc_synchronous; }
 
     bool     isHW() const;
     unsigned getHWSize() const;

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -9621,6 +9621,13 @@ Breakpoint::newHardwareBreakpoint(unsigned int mode, unsigned int size)
     return newbp;
 }
 
+Breakpoint::ptr Breakpoint::newSynchronousBreakpoint() {
+    Breakpoint::ptr newbp = Breakpoint::ptr(new Breakpoint());
+    newbp->llbreakpoint_ = new int_breakpoint(newbp);
+    newbp->llbreakpoint_->makeSynchronous();
+    return newbp;
+}
+
 void*
 Breakpoint::getData() const
 {
@@ -9655,6 +9662,10 @@ bool
 Breakpoint::suppressCallbacks() const
 {
     return llbreakpoint_->suppressCallbacks();
+}
+
+bool Breakpoint::isSynchronous() const {
+  return llbreakpoint_->isSynchronous();
 }
 
 // Note: These locks are intentionally indirect and leaked!


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fixes 2 bugs:
 1. Forces the main breakpoint to `sync_process`, i.e. it forces all existing threads into a stopped state. Prevents a crash
 2. In the case where a worker thread exits before their corresponding `LWPCreate` and `LWPDestroy` events can be handled, ignore those events. Prevents a crash.
 
 With this, `runtime-instrumentation` will now work with OpenMP.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
