### PR TITLE
Fix configuration errors when using external Boost

### DIFF
--- a/cmake/tpls/DyninstBoost.cmake
+++ b/cmake/tpls/DyninstBoost.cmake
@@ -56,7 +56,9 @@ if(NOT TARGET Dyninst::Boost)
   target_include_directories(Dyninst::Boost SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})
   target_compile_definitions(Dyninst::Boost
                              INTERFACE BOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
+endif()
 
+if(NOT TARGET Dyninst::Boost_headers)
   # Just the headers (effectively a simplified Boost::headers target)
   add_library(Dyninst::Boost_headers INTERFACE IMPORTED)
   target_include_directories(Dyninst::Boost_headers SYSTEM

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_guard(GLOBAL)
 
 include(DyninstLibrary)
+include(DyninstBoost)
 
 configure_file(${PROJECT_SOURCE_DIR}/cmake/dyninstversion.h.in
                ${CMAKE_CURRENT_SOURCE_DIR}/h/dyninstversion.h)
@@ -165,7 +166,7 @@ dyninst_library(
   PRIVATE_HEADER_FILES ${_private_headers}
   SOURCE_FILES ${_sources}
   DEFINES COMMON_LIB
-  PUBLIC_DEPS Dyninst::TBB Dyninst::Boost
+  PUBLIC_DEPS Dyninst::TBB Dyninst::Boost Boost::thread Boost::filesystem
   PRIVATE_DEPS Dyninst::LibIberty OpenMP::OpenMP_CXX Dyninst::Valgrind Threads::Threads
 )
 # cmake-format: on

--- a/dwarf/CMakeLists.txt
+++ b/dwarf/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_guard(GLOBAL)
 
 include(DyninstLibrary)
+include(DyninstBoost)
 
 if(NOT DYNINST_OS_UNIX)
   if(NOT TARGET dynDwarf)

--- a/dyninstAPI/CMakeLists.txt
+++ b/dyninstAPI/CMakeLists.txt
@@ -7,6 +7,7 @@ if(LIGHTWEIGHT_SYMTAB)
 endif()
 
 include(DyninstLibrary)
+include(DyninstBoost)
 
 set(_public_headers
     h/BPatch_addressSpace.h

--- a/elf/CMakeLists.txt
+++ b/elf/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_guard(GLOBAL)
 
 include(DyninstLibrary)
+include(DyninstBoost)
 
 if(NOT DYNINST_OS_UNIX)
   if(NOT TARGET dynElf)

--- a/instructionAPI/CMakeLists.txt
+++ b/instructionAPI/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_guard(GLOBAL)
 
 include(DyninstLibrary)
+include(DyninstBoost)
 
 set(_sources
     src/debug.C

--- a/parseAPI/CMakeLists.txt
+++ b/parseAPI/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_guard(GLOBAL)
 
 include(DyninstLibrary)
+include(DyninstBoost)
 
 set(SRC_LIST
     src/ParserDetails.C

--- a/proccontrol/CMakeLists.txt
+++ b/proccontrol/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_guard(GLOBAL)
 
 include(DyninstLibrary)
+include(DyninstBoost)
 
 set(_public_headers
     h/Decoder.h

--- a/stackwalk/CMakeLists.txt
+++ b/stackwalk/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_guard(GLOBAL)
 
 include(DyninstLibrary)
+include(DyninstBoost)
 
 set(_public_headers
     h/basetypes.h


### PR DESCRIPTION
## Motivation
Enables configuring rocprof-systems with an external Boost library (`ROCPROFSYS_BUILD_BOOST=OFF`).

## Technical Details

Some targets are missing Boost components in target_link_libraries, leaving some symbols unresolved at link time.

Fix Dyninst::Boost_headers target not being found by CMake.

## Test Plan

Configure and build rocprof-systems with an external Boost library, such as the one installed by [Ubuntu's DEB package](https://packages.ubuntu.com/jammy/libboost-dev).

## Test Result

After the fix, it was possible to build and install rocprof-systems using an external boost installation, reducing the total compilation time significantly.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
