### PR TITLE
Cherry pick proccontrol patches

### DIFF
--- a/dyninstAPI/src/dynProcess.C
+++ b/dyninstAPI/src/dynProcess.C
@@ -963,8 +963,10 @@ bool PCProcess::insertBreakpointAtMain() {
     }
     Dyninst::Address addr = main_function_->addr();
 
-    // Create the breakpoint
-    mainBrkPt_ = Breakpoint::newBreakpoint();
+    // Libraries loaded before reaching 'main' can launch threads, so
+    // ensure they are all stopped before "executing" this breakpoint.
+    mainBrkPt_ = Breakpoint::newSynchronousBreakpoint();
+
     if( !pcProc_->addBreakpoint(addr, mainBrkPt_) ) {
         startup_printf("%s[%d]: failed to insert a breakpoint at main entry: 0x%lx\n",
                 FILE__, __LINE__, addr);

--- a/dyninstAPI/src/pcEventHandler.C
+++ b/dyninstAPI/src/pcEventHandler.C
@@ -367,6 +367,15 @@ bool PCEventHandler::handleThreadCreate(EventNewThread::const_ptr ev, PCProcess 
   proccontrol_printf("%s[%d]: entering handleThreadCreate for %d/%d\n",
 		     FILE__, __LINE__, evProc->getPid(), ev->getLWP());
 
+    // Check if the thread still exists
+#if defined(os_linux) || defined(os_freebsd)
+    if (!ev->getNewThread()) {
+        proccontrol_printf("%s[%d]: thread %d/%d not found, it may have already exited. Ignoring thread create event.\n",
+            FILE__, __LINE__, evProc->getPid(), ev->getLWP());
+            return true;
+    }
+#endif
+
     if( !ev->getNewThread()->haveUserThreadInfo() ) {
         proccontrol_printf("%s[%d]: no user thread info for thread %d/%d, postponing thread create\n",
                 FILE__, __LINE__, evProc->getPid(), ev->getLWP());
@@ -423,6 +432,13 @@ bool PCEventHandler::handleThreadDestroy(EventThreadDestroy::const_ptr ev, PCPro
 			 FILE__, __LINE__, evProc->getPid(), ev->getThread()->getLWP()); 
         BPatch_process *bpproc = BPatch::bpatch->getProcessByPid(evProc->getPid());
         if( bpproc == NULL ) {
+#if defined(os_linux) || defined(os_freebsd)
+            if (ev->getEventType().code() == EventType::LWPDestroy) {
+                proccontrol_printf("%s[%d]: failed to locate process %d, for corresponding LWPDestroy event. It may have already exited. Ignoring event.\n",
+                    FILE__, __LINE__, evProc->getPid());
+                return true;
+            }
+#endif
             proccontrol_printf("%s[%d]: failed to locate BPatch_process for process %d\n",
                     FILE__, __LINE__, evProc->getPid());
             return false;

--- a/proccontrol/h/PCProcess.h
+++ b/proccontrol/h/PCProcess.h
@@ -129,6 +129,7 @@ class PC_EXPORT Breakpoint
    static Breakpoint::ptr newTransferBreakpoint(Dyninst::Address to);
    static Breakpoint::ptr newTransferOffsetBreakpoint(signed long shift);
    static Breakpoint::ptr newHardwareBreakpoint(unsigned int mode, unsigned int size);
+   static Breakpoint::ptr newSynchronousBreakpoint();
 
    void *getData() const;
    void setData(void *p) const;
@@ -138,6 +139,8 @@ class PC_EXPORT Breakpoint
 
    void setSuppressCallbacks(bool);
    bool suppressCallbacks() const;
+   
+   bool isSynchronous() const;
 };
 
 class PC_EXPORT Library

--- a/proccontrol/src/event.C
+++ b/proccontrol/src/event.C
@@ -535,6 +535,17 @@ Dyninst::LWP EventNewLWP::getLWP() const
 Thread::const_ptr EventNewLWP::getNewThread() const
 {
    int_thread *thr = getProcess()->llproc()->threadPool()->findThreadByLWP(lwp);
+   
+#if defined(os_linux) || defined(os_freebsd)
+   if (!thr) {
+      int pid = getProcess()->llproc()->getPid();
+      if (lwp != pid) {
+         pthrd_printf("Non-main thread %d/%d not found\n", pid, lwp);
+         return Thread::const_ptr();
+      }
+   }
+#endif
+
    assert(thr);
    return thr->thread();
 }

--- a/proccontrol/src/int_process.h
+++ b/proccontrol/src/int_process.h
@@ -1304,6 +1304,10 @@ class int_breakpoint
    bool procstopper;
    bool suppress_callbacks;
    bool offset_transfer;
+
+   // all threads in process need to be synchronized at this breakpoint
+   bool is_proc_synchronous{false};
+
    std::set<Thread::const_ptr> thread_specific;
  public:
    int_breakpoint(Breakpoint::ptr up);
@@ -1330,6 +1334,9 @@ class int_breakpoint
 
    void setSuppressCallbacks(bool);
    bool suppressCallbacks(void) const;
+   
+   void makeSynchronous() { is_proc_synchronous = true; }
+   bool isSynchronous() const { return is_proc_synchronous; }
 
    bool isHW() const;
    unsigned getHWSize() const;

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -8269,6 +8269,13 @@ Breakpoint::ptr Breakpoint::newHardwareBreakpoint(unsigned int mode,
   return newbp;
 }
 
+Breakpoint::ptr Breakpoint::newSynchronousBreakpoint() {
+  Breakpoint::ptr newbp = Breakpoint::ptr(new Breakpoint());
+  newbp->llbreakpoint_ = new int_breakpoint(newbp);
+  newbp->llbreakpoint_->makeSynchronous();
+  return newbp;
+}
+
 void *Breakpoint::getData() const {
    return llbreakpoint_->getData();
 }
@@ -8294,6 +8301,10 @@ void Breakpoint::setSuppressCallbacks(bool b)
 bool Breakpoint::suppressCallbacks() const
 {
    return llbreakpoint_->suppressCallbacks();
+}
+
+bool Breakpoint::isSynchronous() const {
+  return llbreakpoint_->isSynchronous();
 }
 
 // Note: These locks are intentionally indirect and leaked!


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

These two PRs fix an issue that plagued `runtime-instrument` involving OpenMP offloading programs.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

See both original PRs:
- https://github.com/dyninst/dyninst/pull/2137
- https://github.com/dyninst/dyninst/pull/2131

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Build `rocprofiler-systems` with these changes and verify `openmp-vv-offload-.*-runtime-instrument` tests pass

## Test Result

<!-- Briefly summarize test outcomes. -->

Build successful and tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
