### PR TITLE
include stdint.h and cstdint explicitly for newer gcc versions

### DIFF
--- a/common/src/arch-x86.h
+++ b/common/src/arch-x86.h
@@ -36,6 +36,7 @@
 
 #include "dyntypes.h"
 #include <assert.h>
+#include <cstdint>
 #include <stdio.h>
 #include <set>
 #include <map>

--- a/common/src/sha1.C
+++ b/common/src/sha1.C
@@ -100,6 +100,7 @@ A million repetitions of "a"
 /* #define SHA1HANDSOFF  */
 
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/instructionAPI/h/ArchSpecificFormatters.h
+++ b/instructionAPI/h/ArchSpecificFormatters.h
@@ -33,6 +33,7 @@
 
 #include <map>
 #include <vector>
+#include <cstdint>
 #include <string>
 #include "Architecture.h"
 #include "registers/MachRegister.h"


### PR DESCRIPTION
Never c/c++ header versions provided by the gcc 15
requires that stdint.h and cstdint needs to be included excplicitly
to avoid build errors related to types like uint32_t.
    
Fixes following type of errors with gcc 15:
    
/therock/rocm-systems/projects/rocprofiler-systems/external/dyninst/common/src/sha1.C:112:5:
error: ‘uint32_t’ does not name a type
10.6      112 |     uint32_t state[5];
    
and
    
‘INT32_MAX’ was not declared in this scope