### PR TITLE
[Cherry-pick] Implement `isSharedLib` for `BPatch_object`

### DIFF
--- a/dyninstAPI/h/BPatch_object.h
+++ b/dyninstAPI/h/BPatch_object.h
@@ -104,11 +104,15 @@ class BPATCH_DLL_EXPORT BPatch_object {
 
     // BPatch_object::name
     // Returns the file name of the object
-    std::string name();
+    std::string name() const;
 
     // BPatch_object::pathName
     // Returns the full pathname of the object
-    std::string pathName();
+    std::string pathName() const;
+
+    // BPatch_object::isSharedLib
+    // Returns true if this object represents a shared library
+    bool isSharedLib() const;
 
     
     // BPatch_object::offsetToAddr

--- a/dyninstAPI/src/BPatch_object.C
+++ b/dyninstAPI/src/BPatch_object.C
@@ -72,12 +72,16 @@ AddressSpace *BPatch_object::ll_as() { return obj->proc(); }
 
 BPatch_addressSpace *BPatch_object::as() { return img->getAddressSpace(); }
 
-std::string BPatch_object::name() {
+std::string BPatch_object::name() const {
    return obj->fileName();
 }
 
-std::string BPatch_object::pathName() {
+std::string BPatch_object::pathName() const {
    return obj->fullName();
+}
+
+bool BPatch_object::isSharedLib() const {
+   return obj->isSharedLib();
 }
 
 Dyninst::Address BPatch_object::fileOffsetToAddr(const Dyninst::Offset fileOffset) {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Cherry pick 635cacdfc23bf98f930dd278a2ac429c435e2a5c from https://github.com/dyninst/dyninst

This adds the `isSharedLib()` to `BPatch_object`, allowing a quicker way of filtering out shared libraries.
This way we can avoid going through the SymTab API or `BPatch_module`

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

See https://github.com/dyninst/dyninst/pull/2215 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
