### PR TITLE
Add CODEOWNERS file for ROCm team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ROCm/rocprof-sys


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Add CODEOWNERS file to `dyninst_13` branch. CODEOWNER files are required for all public repos and ours was found missing from an org-wide audit

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add default reviewer `ROCm/rocprof-sys`

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
