### PR TITLE
[Cherry-pick] Fix ELF boundary check in code segment selection

### DIFF
--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -2385,9 +2385,9 @@ void Object::find_code_and_data(Elf_X &elf,
         // txtaddr=0, so in this case we set these values by
         // identifying the segment that contains the entryAddress
         if (((phdr.p_vaddr() <= txtaddr) &&
-             (phdr.p_vaddr() + phdr.p_filesz() >= txtaddr)) ||
+             (phdr.p_vaddr() + phdr.p_filesz() > txtaddr)) ||
             (!txtaddr && ((phdr.p_vaddr() <= entryAddress_) &&
-                          (phdr.p_vaddr() + phdr.p_filesz() >= entryAddress_)))) {
+                          (phdr.p_vaddr() + phdr.p_filesz() > entryAddress_)))) {
 
             if (code_ptr_ == 0 && code_off_ == 0 && code_len_ == 0) {
                 code_ptr_ = (char *) (void *) &file_ptr[phdr.p_offset()];
@@ -2396,7 +2396,7 @@ void Object::find_code_and_data(Elf_X &elf,
             }
 
         } else if (((phdr.p_vaddr() <= dataddr) &&
-                    (phdr.p_vaddr() + phdr.p_filesz() >= dataddr)) ||
+                    (phdr.p_vaddr() + phdr.p_filesz() > dataddr)) ||
                    (!dataddr && (phdr.p_type() == PT_LOAD))) {
             if (data_ptr_ == 0 && data_off_ == 0 && data_len_ == 0) {
                 data_ptr_ = (char *) (void *) &file_ptr[phdr.p_offset()];


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Cherry pick 5d2c62a4ca3638f8bb04d5c596b4d928ea595998 from https://github.com/dyninst/dyninst

This modifies the boundary check in the `find_code_from_data` function from inclusive to a half-open boundary.
Without this, it can choose the incorrect `PT_LOAD` segment when `.text` starts exactly at the end address of a previous load segment.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Change the following comparisons from `>=` to `>`
 - https://github.com/dyninst/dyninst/blob/master/symtabAPI/src/Object-elf.C#L2318
 - https://github.com/dyninst/dyninst/blob/master/symtabAPI/src/Object-elf.C#L2320
 - https://github.com/dyninst/dyninst/blob/master/symtabAPI/src/Object-elf.C#L2329

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

PR was tested using the original reproducer that warranted this PR: AIPROFSYST-179.
PR was also testing using head of dyninst on a custom walker.


## Test Result

<!-- Briefly summarize test outcomes. -->

`rocprof-sys-instrument` in binary-rewrite mode no longer crashes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
