### PR TITLE
Fix shell-splits CMAKE_C_FLAGS and CMAKE_CXX_FLAGS

### DIFF
--- a/cmake/DyninstOptimization.cmake
+++ b/cmake/DyninstOptimization.cmake
@@ -97,9 +97,11 @@ endif()
 #   ${CMAKE_<LANG>_FLAGS} ${CMAKE_<LANG>_FLAGS_<BUILD>} <options> ${CMAKE_<LANG>_FLAGS}
 #
 string(TOUPPER ${CMAKE_BUILD_TYPE} _build_type)
-set(DYNINST_C_FLAGS_${_build_type} ${_${_build_type}} ${CMAKE_C_FLAGS})
+separate_arguments(_dyninst_c_flags UNIX_COMMAND "${CMAKE_C_FLAGS}")
+separate_arguments(_dyninst_cxx_flags UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
+set(DYNINST_C_FLAGS_${_build_type} ${_${_build_type}} ${_dyninst_c_flags})
 set(DYNINST_CXX_FLAGS_${_build_type} ${_${_build_type}} ${DYNINST_CXX_FLAGS}
-                                     ${CMAKE_CXX_FLAGS})
+                                     ${_dyninst_cxx_flags})
 unset(_build_type)
 
 # Merge the link flags for C++

--- a/common/src/AST.C
+++ b/common/src/AST.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "DynAST.h"
 #include "../../dyninstAPI/src/debug.h"
 #include "../../common/src/singleton_object_pool.h"

--- a/common/src/Annotatable.C
+++ b/common/src/Annotatable.C
@@ -30,6 +30,7 @@
 
 // $Id: Annotatable.C,v 1.12 2008/11/03 15:19:23 jaw Exp $
 
+#include <algorithm>
 #include "common/src/headers.h"
 #include "dyntypes.h"
 #include "Annotatable.h"

--- a/common/src/Buffer.C
+++ b/common/src/Buffer.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "Buffer.h"
 #include <stdlib.h>
 

--- a/common/src/DOT.C
+++ b/common/src/DOT.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
  
+#include <algorithm>
 #include "Graph.h"
 #include "Node.h"
 #include "Edge.h"

--- a/common/src/Edge.C
+++ b/common/src/Edge.C
@@ -30,6 +30,7 @@
 
 // Edge class implementation
 
+#include <algorithm>
 #include "Graph.h"
 #include "Edge.h"
 #include "Node.h"

--- a/common/src/Graph.C
+++ b/common/src/Graph.C
@@ -30,6 +30,7 @@
 
 // Graph class implementation
 
+#include <algorithm>
 #include "Graph.h"
 #include "Edge.h"
 #include "Node.h"

--- a/common/src/MachSyscall.C
+++ b/common/src/MachSyscall.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "MachSyscall.h"
 #include "dyntypes.h"
 

--- a/common/src/MappedFile.C
+++ b/common/src/MappedFile.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "common/src/MappedFile.h"
 #include "common/src/pathName.h"
 #include <iostream>

--- a/common/src/Node.C
+++ b/common/src/Node.C
@@ -31,6 +31,7 @@
 
 // Node class implementation
 
+#include <algorithm>
 #include "Graph.h"
 #include "Edge.h"
 #include "Node.h"

--- a/common/src/addrtranslate-sysv.C
+++ b/common/src/addrtranslate-sysv.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <assert.h>
 #include <link.h>
 #include <stdio.h>

--- a/common/src/arch-x86.C
+++ b/common/src/arch-x86.C
@@ -129,6 +129,7 @@
 
 
 // This include *really must* come first in the file.
+#include <algorithm>
 #include "common/src/vgannotations.h"
 
 #include <assert.h>

--- a/common/src/freebsdKludges.C
+++ b/common/src/freebsdKludges.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "freebsdKludges.h"
 #include "common/src/headers.h"
 #include <sys/sysctl.h>

--- a/common/src/registers/MachRegister.C
+++ b/common/src/registers/MachRegister.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "common/h/registers/MachRegister.h"
 #include "debug_common.h"
 #include "dyn_regs.h"

--- a/common/src/stats.C
+++ b/common/src/stats.C
@@ -33,6 +33,7 @@
  * $Id: stats.C,v 1.2 2008/07/01 19:26:49 legendre Exp $
  */
 
+#include <algorithm>
 #include "common/src/headers.h"
 #include "common/src/stats.h"
 #include "common/h/util.h"

--- a/dataflowAPI/rose/ExtentMap.C
+++ b/dataflowAPI/rose/ExtentMap.C
@@ -3,6 +3,7 @@
  * single extent.  This class is used to keep track of what parts of a binary file have been parsed, and is also used to
  * manage string table free lists, among other things. */
 
+#include <algorithm>
 #include "util/StringUtility.h"
 #include "ExtentMap.h"
 #include <cstring>

--- a/dataflowAPI/rose/semantics/BaseSemantics2.C
+++ b/dataflowAPI/rose/semantics/BaseSemantics2.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "../util/StringUtility.h"
 //#include "sage3basic.h"
 #include "BaseSemantics2.h"

--- a/dataflowAPI/rose/semantics/BinarySymbolicExpr.C
+++ b/dataflowAPI/rose/semantics/BinarySymbolicExpr.C
@@ -1,6 +1,7 @@
 #define __STDC_LIMIT_MACROS
 
 //#include "sage3basic.h"
+#include <algorithm>
 #include "../util/StringUtility.h"
 
 #include "BinarySymbolicExpr.h"

--- a/dataflowAPI/rose/semantics/ConcreteSemantics2.C
+++ b/dataflowAPI/rose/semantics/ConcreteSemantics2.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "../util/StringUtility.h"
 //#include "sage3basic.h"
 #include "ConcreteSemantics2.h"

--- a/dataflowAPI/rose/semantics/MemoryMap.C
+++ b/dataflowAPI/rose/semantics/MemoryMap.C
@@ -1,4 +1,5 @@
 //#include "sage3basic.h"
+#include <algorithm>
 #include "../util/StringUtility.h"
 
 //#include "Diagnostics.h"

--- a/dataflowAPI/rose/semantics/RegisterStateGeneric.C
+++ b/dataflowAPI/rose/semantics/RegisterStateGeneric.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "../util/StringUtility.h"
 //#include <sage3basic.h>
 //#include <Diagnostics.h>

--- a/dataflowAPI/rose/semantics/SymEvalSemantics.C
+++ b/dataflowAPI/rose/semantics/SymEvalSemantics.C
@@ -2,6 +2,7 @@
 // Created by ssunny on 7/1/16.
 //
 
+#include <algorithm>
 #include "SymEvalSemantics.h"
 
 #include "Register.h"

--- a/dataflowAPI/rose/util/Message.C
+++ b/dataflowAPI/rose/util/Message.C
@@ -5,6 +5,7 @@
 
 
 
+#include <algorithm>
 #include "Message.h"
 
 #include <dyncompat/algorithm/string/case_conv.hpp>

--- a/dataflowAPI/src/ABI.C
+++ b/dataflowAPI/src/ABI.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "dataflowAPI/h/ABI.h"
 #include "dataflowAPI/src/RegisterMap.h"
 #include <stdio.h>

--- a/dataflowAPI/src/Absloc.C
+++ b/dataflowAPI/src/Absloc.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "Absloc.h"
 #include <assert.h>
 

--- a/dataflowAPI/src/AbslocInterface.C
+++ b/dataflowAPI/src/AbslocInterface.C
@@ -29,6 +29,7 @@
  */
 
 
+#include <algorithm>
 #include <deque>
 #include "Absloc.h"
 #include "AbslocInterface.h"

--- a/dataflowAPI/src/InstructionCache.C
+++ b/dataflowAPI/src/InstructionCache.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "InstructionCache.h"
 using namespace Dyninst;
 using namespace Dyninst::ParseAPI;

--- a/dataflowAPI/src/RoseInsnFactory.C
+++ b/dataflowAPI/src/RoseInsnFactory.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "RoseInsnFactory.h"
 
 #include "Instruction.h"

--- a/dataflowAPI/src/SymEval.C
+++ b/dataflowAPI/src/SymEval.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <string>
 #include <iostream>
 #include <memory>

--- a/dataflowAPI/src/convertOpcodes.C
+++ b/dataflowAPI/src/convertOpcodes.C
@@ -32,6 +32,7 @@
 
 //#include "SymEval.h"
 //#include "SymEvalPolicy.h"
+#include <algorithm>
 #include "RoseInsnFactory.h"
 
 #include "../rose/RegisterDescriptor.h"

--- a/dataflowAPI/src/liveness.C
+++ b/dataflowAPI/src/liveness.C
@@ -30,6 +30,7 @@
 
 // $Id: liveness.C,v 1.12 2008/09/04 21:06:20 bill Exp $
 
+#include <algorithm>
 #include "debug_dataflow.h"
 #include "parseAPI/h/CFG.h"
 #include "parseAPI/h/Location.h"

--- a/dataflowAPI/src/slicing.C
+++ b/dataflowAPI/src/slicing.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include <set>
 #include <vector>
 #include <map>

--- a/dataflowAPI/src/stackanalysis.C
+++ b/dataflowAPI/src/stackanalysis.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackanalysis.h"
 
 #include <dyncompat/bind/bind.hpp>

--- a/dwarf/src/dwarfFrameParser.C
+++ b/dwarf/src/dwarfFrameParser.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "common/src/vgannotations.h"
 #include <typeinfo>
 #include <string.h>

--- a/dwarf/src/dwarfHandle.C
+++ b/dwarf/src/dwarfHandle.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "elfutils/libdw.h"
 #include "elfutils/libdwfl.h"
 #include "Elf_X.h"

--- a/dynC_API/src/dynC.tab.C
+++ b/dynC_API/src/dynC.tab.C
@@ -83,6 +83,7 @@
 
 
 
+#include <algorithm>
 #include <stdio.h>
 #include <vector>
 #include <string>

--- a/dyninstAPI/src/BPatch.C
+++ b/dyninstAPI/src/BPatch.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <stdio.h>
 #include <assert.h>
 #include <signal.h>

--- a/dyninstAPI/src/BPatch_basicBlock.C
+++ b/dyninstAPI/src/BPatch_basicBlock.C
@@ -30,6 +30,7 @@
 
 #define BPATCH_FILE
 
+#include <algorithm>
 #include <stdio.h>
 #include <iostream>
 #include <dyncompat/bind/bind.hpp>

--- a/dyninstAPI/src/BPatch_binaryEdit.C
+++ b/dyninstAPI/src/BPatch_binaryEdit.C
@@ -30,6 +30,7 @@
 
 #define BPATCH_FILE
 
+#include <algorithm>
 #include "binaryEdit.h"
 #include "addressSpace.h"
 #include "inst.h"

--- a/dyninstAPI/src/BPatch_collections.C
+++ b/dyninstAPI/src/BPatch_collections.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <stdio.h>
 
 #define BPATCH_FILE

--- a/dyninstAPI/src/BPatch_flowGraph.C
+++ b/dyninstAPI/src/BPatch_flowGraph.C
@@ -30,6 +30,7 @@
 
 #define BPATCH_FILE
 
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/dyninstAPI/src/BPatch_function.C
+++ b/dyninstAPI/src/BPatch_function.C
@@ -32,6 +32,7 @@
 
 #define BPATCH_FILE
 
+#include <algorithm>
 #include <string.h>
 #include <string>
 #include "function.h"

--- a/dyninstAPI/src/BPatch_image.C
+++ b/dyninstAPI/src/BPatch_image.C
@@ -32,6 +32,7 @@
 
 #define BPATCH_FILE
 
+#include <algorithm>
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>

--- a/dyninstAPI/src/BPatch_module.C
+++ b/dyninstAPI/src/BPatch_module.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <stdio.h>
 #include <ctype.h>
 #include <string>

--- a/dyninstAPI/src/BPatch_object.C
+++ b/dyninstAPI/src/BPatch_object.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/dyninstAPI/src/BPatch_process.C
+++ b/dyninstAPI/src/BPatch_process.C
@@ -30,6 +30,7 @@
 
 #define BPATCH_FILE
 
+#include <algorithm>
 #include <string>
 
 #include "inst.h"

--- a/dyninstAPI/src/BPatch_snippet.C
+++ b/dyninstAPI/src/BPatch_snippet.C
@@ -32,6 +32,7 @@
 
 #define BPATCH_FILE
 
+#include <algorithm>
 #include <string.h>
 
 #include "BPatch.h"

--- a/dyninstAPI/src/BPatch_sourceBlock.C
+++ b/dyninstAPI/src/BPatch_sourceBlock.C
@@ -30,6 +30,7 @@
 
 #define BPATCH_FILE
 
+#include <algorithm>
 #include <stdio.h>
 #include "BPatch_sourceBlock.h"
 #include <iterator>

--- a/dyninstAPI/src/BPatch_type.C
+++ b/dyninstAPI/src/BPatch_type.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <stdio.h>
 
 #define BPATCH_FILE

--- a/dyninstAPI/src/Parsing.C
+++ b/dyninstAPI/src/Parsing.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include <stdio.h>
 
 #include "InstructionDecoder.h"

--- a/dyninstAPI/src/RegisterConversion-aarch64.C
+++ b/dyninstAPI/src/RegisterConversion-aarch64.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "RegisterConversion.h"
 #include "registerSpace.h"
 

--- a/dyninstAPI/src/RegisterConversion-ppc.C
+++ b/dyninstAPI/src/RegisterConversion-ppc.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "RegisterConversion.h"
 #include "registerSpace.h"
 

--- a/dyninstAPI/src/RegisterConversion-x86.C
+++ b/dyninstAPI/src/RegisterConversion-x86.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "RegisterConversion.h"
 #include "inst-x86.h"
 

--- a/dyninstAPI/src/Relocation/CFG/RelocBlock.C
+++ b/dyninstAPI/src/Relocation/CFG/RelocBlock.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <iostream>
 #include <iomanip>
 

--- a/dyninstAPI/src/Relocation/CFG/RelocEdge.C
+++ b/dyninstAPI/src/Relocation/CFG/RelocEdge.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "RelocBlock.h"
 #include "RelocTarget.h"
 #include "RelocEdge.h"

--- a/dyninstAPI/src/Relocation/CFG/RelocGraph.C
+++ b/dyninstAPI/src/Relocation/CFG/RelocGraph.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "RelocGraph.h"
 #include "RelocBlock.h"
 #include <iostream>

--- a/dyninstAPI/src/Relocation/CodeBuffer.C
+++ b/dyninstAPI/src/Relocation/CodeBuffer.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "CodeBuffer.h"
 #include "CodeTracker.h"
 #include "Widgets/Widget.h" //  Currently Patch is defined here; we may want to move it.

--- a/dyninstAPI/src/Relocation/CodeMover.C
+++ b/dyninstAPI/src/Relocation/CodeMover.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "Relocation.h"
 #include "CodeMover.h"
 #include "Widgets/Widget.h"

--- a/dyninstAPI/src/Relocation/CodeTracker.C
+++ b/dyninstAPI/src/Relocation/CodeTracker.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "CodeTracker.h"
 #include "dyninstAPI/src/debug.h"
 #include "dyninstAPI/src/function.h"

--- a/dyninstAPI/src/Relocation/DynInstrumenter.C
+++ b/dyninstAPI/src/Relocation/DynInstrumenter.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "DynInstrumenter.h"
 #include "BPatch_point.h"
 #include "BPatch_addressSpace.h"

--- a/dyninstAPI/src/Relocation/Springboard.C
+++ b/dyninstAPI/src/Relocation/Springboard.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "CFG.h"
 #include "Springboard.h"
 #include "dyninstAPI/src/debug.h"

--- a/dyninstAPI/src/Relocation/Transformers/Instrumenter.C
+++ b/dyninstAPI/src/Relocation/Transformers/Instrumenter.C
@@ -30,6 +30,7 @@
 
 
 
+#include <algorithm>
 #include "Transformer.h"
 #include "Instrumenter.h"
 #include "dyninstAPI/src/debug.h"

--- a/dyninstAPI/src/Relocation/Transformers/Modification.C
+++ b/dyninstAPI/src/Relocation/Transformers/Modification.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "Transformer.h"
 #include "Modification.h"
 #include "dyninstAPI/src/debug.h"

--- a/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-adhoc.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "Transformer.h"
 #include "Movement-adhoc.h"
 #include "dyninstAPI/src/debug.h"

--- a/dyninstAPI/src/Relocation/Transformers/Movement-analysis.C
+++ b/dyninstAPI/src/Relocation/Transformers/Movement-analysis.C
@@ -30,6 +30,7 @@
 
 
 
+#include <algorithm>
 #include "Transformer.h"
 #include "Movement-analysis.h"
 #include "Modification.h"

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget-x86.C
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget-x86.C
@@ -29,6 +29,7 @@
  */
 // x86-specific methods for generating control flow
 
+#include <algorithm>
 #include "CFWidget.h"
 #include "Widget.h"
 #include "../CFG/RelocTarget.h"

--- a/dyninstAPI/src/Relocation/Widgets/CFWidget.C
+++ b/dyninstAPI/src/Relocation/Widgets/CFWidget.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "CFWidget.h"
 #include "Widget.h"
 #include "../CFG/RelocTarget.h"

--- a/dyninstAPI/src/StackMod/OffsetVector.C
+++ b/dyninstAPI/src/StackMod/OffsetVector.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "debug.h"
 
 #include "OffsetVector.h"

--- a/dyninstAPI/src/StackMod/StackAccess.C
+++ b/dyninstAPI/src/StackMod/StackAccess.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <sstream>
 
 #include "debug.h"

--- a/dyninstAPI/src/StackMod/StackModChecker.C
+++ b/dyninstAPI/src/StackMod/StackModChecker.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "BPatch.h"
 #include "BPatch_addressSpace.h"
 #include "BPatch_flowGraph.h"

--- a/dyninstAPI/src/StackMod/TMap.C
+++ b/dyninstAPI/src/StackMod/TMap.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "debug.h"
 #include "registers/MachRegister.h"
 

--- a/dyninstAPI/src/addressSpace.C
+++ b/dyninstAPI/src/addressSpace.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "addressSpace.h"
 #include "codeRange.h"
 #include "dynProcess.h"

--- a/dyninstAPI/src/ast.C
+++ b/dyninstAPI/src/ast.C
@@ -30,6 +30,7 @@
 
 // $Id: ast.C,v 1.209 2008/09/15 18:37:49 jaw Exp $
 
+#include <algorithm>
 #include "dyninstAPI/src/image.h"
 #include "function.h"
 #include "inst.h"

--- a/dyninstAPI/src/binaryEdit.C
+++ b/dyninstAPI/src/binaryEdit.C
@@ -30,6 +30,7 @@
 
 // $Id: binaryEdit.C,v 1.26 2008/10/28 18:42:44 bernat Exp $
 
+#include <algorithm>
 #include "binaryEdit.h"
 #include "common/src/headers.h"
 #include "mapped_object.h"

--- a/dyninstAPI/src/codegen-aarch64.C
+++ b/dyninstAPI/src/codegen-aarch64.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <stdlib.h>
 #include "dyninstAPI/src/codegen.h"
 #include "dyninstAPI/src/debug.h"

--- a/dyninstAPI/src/codegen-power.C
+++ b/dyninstAPI/src/codegen-power.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "dyninstAPI/src/codegen.h"
 #include "dyninstAPI/src/debug.h"
 #include "dyninstAPI/src/instPoint.h"

--- a/dyninstAPI/src/codegen.C
+++ b/dyninstAPI/src/codegen.C
@@ -30,6 +30,7 @@
 
 // Code generation
 
+#include <algorithm>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/dyninstAPI/src/dynProcess.C
+++ b/dyninstAPI/src/dynProcess.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "dynProcess.h"
 #include "dynThread.h"
 #include "pcEventHandler.h"

--- a/dyninstAPI/src/emit-x86.C
+++ b/dyninstAPI/src/emit-x86.C
@@ -33,6 +33,7 @@
  * $Id: emit-x86.C,v 1.64 2008/09/11 20:14:14 mlam Exp $
  */
 
+#include <algorithm>
 #include <assert.h>
 #include <stdio.h>
 #include "compiler_annotations.h"

--- a/dyninstAPI/src/freebsd.C
+++ b/dyninstAPI/src/freebsd.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <cassert>
 #include <dlfcn.h>
 #include <cstdlib>

--- a/dyninstAPI/src/function.C
+++ b/dyninstAPI/src/function.C
@@ -30,6 +30,7 @@
 
 // $Id: function.C,v 1.10 2005/03/02 19:44:45 bernat Exp
 
+#include <algorithm>
 #include <random>
 #include "function.h"
 #include "instPoint.h"

--- a/dyninstAPI/src/hybridCallbacks.C
+++ b/dyninstAPI/src/hybridCallbacks.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "hybridAnalysis.h"
 #include "debug.h"
 #include "BPatch_point.h"

--- a/dyninstAPI/src/hybridInstrumentation.C
+++ b/dyninstAPI/src/hybridInstrumentation.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "hybridAnalysis.h"
 #include "BPatch.h"
 #include "BPatch_process.h"

--- a/dyninstAPI/src/hybridOverwrites.C
+++ b/dyninstAPI/src/hybridOverwrites.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "hybridAnalysis.h"
 #include "BPatch_process.h"
 #include "BPatch_function.h"

--- a/dyninstAPI/src/image.C
+++ b/dyninstAPI/src/image.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/dyninstAPI/src/inst-power.C
+++ b/dyninstAPI/src/inst-power.C
@@ -33,6 +33,7 @@
  * $Id: inst-power.C,v 1.291 2008/06/19 22:13:42 jaw Exp $
  */
 
+#include <algorithm>
 #include "common/src/headers.h"
 #include "dyninstAPI/h/BPatch_memoryAccess_NP.h"
 #include "dyninstAPI/src/image.h"

--- a/dyninstAPI/src/inst.C
+++ b/dyninstAPI/src/inst.C
@@ -32,6 +32,7 @@
 // Code to install and remove instrumentation from a running process.
 // Misc constructs.
 
+#include <algorithm>
 #include <assert.h>
 #include "dyninstAPI/src/image.h"
 #include "dyninstAPI/src/inst.h"

--- a/dyninstAPI/src/instPoint.C
+++ b/dyninstAPI/src/instPoint.C
@@ -32,6 +32,7 @@
 // instPoint code
 
 
+#include <algorithm>
 #include <assert.h>
 #include "dyninstAPI/src/image.h"
 #include "dyninstAPI/src/inst.h"

--- a/dyninstAPI/src/linux.C
+++ b/dyninstAPI/src/linux.C
@@ -30,6 +30,7 @@
 
 // $Id: linux.C,v 1.279 2008/09/03 06:08:44 jaw Exp $
 
+#include <algorithm>
 #include "binaryEdit.h"
 #include "dynProcess.h"
 #include "image.h"

--- a/dyninstAPI/src/mapped_module.C
+++ b/dyninstAPI/src/mapped_module.C
@@ -30,6 +30,7 @@
 
 // $Id: mapped_module.C,v 1.29 2008/06/19 19:53:30 legendre Exp $
 
+#include <algorithm>
 #include "dyninstAPI/src/mapped_module.h"
 #include "dyninstAPI/src/mapped_object.h"
 #include "dyninstAPI/src/image.h"

--- a/dyninstAPI/src/parRegion.C
+++ b/dyninstAPI/src/parRegion.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "parRegion.h"
 #include "parse-cfg.h"
 #include "function.h"

--- a/dyninstAPI/src/parse-cfg.C
+++ b/dyninstAPI/src/parse-cfg.C
@@ -30,6 +30,7 @@
  
 // $Id: parse-cfg.C,v 1.60 2008/11/03 15:19:24 jaw Exp $
 
+#include <algorithm>
 #include "function.h"
 #include "instPoint.h"
 

--- a/dyninstAPI/src/pcEventHandler.C
+++ b/dyninstAPI/src/pcEventHandler.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "pcEventHandler.h"
 #include "BPatch.h"
 #include "debug.h"

--- a/dyninstAPI/src/pcEventMuxer.C
+++ b/dyninstAPI/src/pcEventMuxer.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "pcEventMuxer.h"
 #include "pcEventHandler.h"
 #include "BPatch.h"

--- a/dyninstAPI/src/pdwinnt.C
+++ b/dyninstAPI/src/pdwinnt.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <iomanip>
 #include <string>
 #include "common/src/headers.h"

--- a/dyninstAPI/src/registerSpace.C
+++ b/dyninstAPI/src/registerSpace.C
@@ -30,6 +30,7 @@
 
 // $Id: registerSpace.C,v 1.25 2008/10/27 17:23:53 mlam Exp $
 
+#include <algorithm>
 #include "dyninstAPI/src/image.h"
 #include "dyninstAPI/src/inst.h"
 #include "dyninstAPI/src/instP.h"

--- a/dyninstAPI/src/unix.C
+++ b/dyninstAPI/src/unix.C
@@ -30,6 +30,7 @@
 
 // $Id: unix.C,v 1.243 2008/06/30 17:33:31 legendre Exp $
 
+#include <algorithm>
 #include "os.h"
 #include "debug.h"
 #include "mapped_object.h"

--- a/elf/src/Elf_X.C
+++ b/elf/src/Elf_X.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/instructionAPI/src/Immediate.C
+++ b/instructionAPI/src/Immediate.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <string>
 #include <iostream>
 #include <sstream>

--- a/instructionAPI/src/InstructionDecoder-aarch64.C
+++ b/instructionAPI/src/InstructionDecoder-aarch64.C
@@ -29,6 +29,7 @@
  */
 
 #include "InstructionDecoder-aarch64.h"
+#include <algorithm>
 #include "registers/aarch64_regs.h"
 
 namespace Dyninst {

--- a/instructionAPI/src/InstructionDecoder-power.C
+++ b/instructionAPI/src/InstructionDecoder-power.C
@@ -29,6 +29,7 @@
  */
 
 #include "InstructionDecoder-power.h"
+#include <algorithm>
 #include <dyncompat/assign/list_of.hpp>
 #include "../../common/src/singleton_object_pool.h"
 #include <mutex>

--- a/instructionAPI/src/Operation.C
+++ b/instructionAPI/src/Operation.C
@@ -30,6 +30,7 @@
 
 #define INSIDE_INSTRUCTION_API
 
+#include <algorithm>
 #include "common/src/vgannotations.h"
 
 #include "Operation_impl.h"

--- a/parseAPI/doc/example.cc
+++ b/parseAPI/doc/example.cc
@@ -4,6 +4,7 @@
 // Improvements by E. Robbins (er209 at kent dot ac dot uk)
 //
 
+#include <algorithm>
 #include <stdio.h>
 #include <map>
 #include <vector>

--- a/parseAPI/src/BoundFactCalculator.C
+++ b/parseAPI/src/BoundFactCalculator.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "dyntypes.h"
 #include "CodeObject.h"
 #include "CodeSource.h"

--- a/parseAPI/src/BoundFactData.C
+++ b/parseAPI/src/BoundFactData.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "dyntypes.h"
 #include "BoundFactData.h"
 #include "debug_parse.h"

--- a/parseAPI/src/CFGModifier.C
+++ b/parseAPI/src/CFGModifier.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "ParseData.h"
 
 #include "CFGModifier.h"

--- a/parseAPI/src/CodeSource.C
+++ b/parseAPI/src/CodeSource.C
@@ -28,6 +28,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include <vector>
 #include <map>
 #include <iostream>

--- a/parseAPI/src/IA_IAPI.C
+++ b/parseAPI/src/IA_IAPI.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "common/src/vgannotations.h"
 #include "dyntypes.h"
 #include "registers/x86_regs.h"

--- a/parseAPI/src/IA_x86.C
+++ b/parseAPI/src/IA_x86.C
@@ -29,6 +29,7 @@
  */
 
 
+#include <algorithm>
 #include "IA_x86.h"
 #include "Dereference.h"
 #include "Immediate.h"

--- a/parseAPI/src/IndirectAnalyzer.C
+++ b/parseAPI/src/IndirectAnalyzer.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "dyntypes.h"
 #include "IndirectAnalyzer.h"
 

--- a/parseAPI/src/JumpTableFormatPred.C
+++ b/parseAPI/src/JumpTableFormatPred.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "JumpTableFormatPred.h"
 #include "SymbolicExpression.h"
 #include "IndirectASTVisitor.h"

--- a/parseAPI/src/JumpTableIndexPred.C
+++ b/parseAPI/src/JumpTableIndexPred.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "dyntypes.h"
 #include "Node.h"
 #include "Graph.h"

--- a/parseAPI/src/LoopAnalyzer.C
+++ b/parseAPI/src/LoopAnalyzer.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/parseAPI/src/ParseData.C
+++ b/parseAPI/src/ParseData.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "ParseData.h"
 #include "Parser.h"
 #include "CodeObject.h"

--- a/parseAPI/src/ParserDetails.C
+++ b/parseAPI/src/ParserDetails.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "ParseData.h"
 
 #include "CodeObject.h"

--- a/parseAPI/src/SymLiteCodeSource.C
+++ b/parseAPI/src/SymLiteCodeSource.C
@@ -28,6 +28,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include <vector>
 #include <map>
 

--- a/parseAPI/src/SymbolicExpression.C
+++ b/parseAPI/src/SymbolicExpression.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "SymbolicExpression.h"
 #include "SymEval.h"
 #include "Absloc.h"

--- a/parseAPI/src/SymtabCodeSource.C
+++ b/parseAPI/src/SymtabCodeSource.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include <vector>
 #include <map>
 #include <atomic>

--- a/parseAPI/src/ThunkData.C
+++ b/parseAPI/src/ThunkData.C
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "dyntypes.h"
 #include "ThunkData.h"
 #include "IndirectASTVisitor.h"

--- a/parseAPI/src/dominator.C
+++ b/parseAPI/src/dominator.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "CFG.h"
 #include <iostream>
 #include <set>

--- a/patchAPI/src/AddrSpace.C
+++ b/patchAPI/src/AddrSpace.C
@@ -29,6 +29,7 @@
  */
 /* Public Interface */
 
+#include <algorithm>
 #include "AddrSpace.h"
 #include "PatchObject.h"
 #include "PatchMgr.h"

--- a/patchAPI/src/Instrumenter.C
+++ b/patchAPI/src/Instrumenter.C
@@ -29,6 +29,7 @@
  */
 /* Plugin */
 
+#include <algorithm>
 #include "Instrumenter.h"
 #include "PatchCFG.h"
 

--- a/patchAPI/src/PatchBlock.C
+++ b/patchAPI/src/PatchBlock.C
@@ -29,6 +29,7 @@
  */
 /* Public Interface */
 
+#include <algorithm>
 #include "PatchCommon.h"
 #include "PatchCFG.h"
 #include "AddrSpace.h"

--- a/patchAPI/src/PatchFunction.C
+++ b/patchAPI/src/PatchFunction.C
@@ -29,6 +29,7 @@
  */
 /* Public Interface */
 
+#include <algorithm>
 #include "PatchCFG.h"
 #include "PatchMgr.h"
 #include "PatchCallback.h"

--- a/patchAPI/src/PatchMgr.C
+++ b/patchAPI/src/PatchMgr.C
@@ -29,6 +29,7 @@
  */
 /* Public Interface */
 
+#include <algorithm>
 #include "PatchMgr.h"
 #include "PatchObject.h"
 #include "PatchCFG.h"

--- a/patchAPI/src/PatchModifier.C
+++ b/patchAPI/src/PatchModifier.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "PatchModifier.h"
 #include "PatchCFG.h"
 #include "PatchMgr.h"

--- a/patchAPI/src/PatchObject.C
+++ b/patchAPI/src/PatchObject.C
@@ -29,6 +29,7 @@
  */
 /* Plugin */
 
+#include <algorithm>
 #include "PatchObject.h"
 #include "PatchCFG.h"
 #include "AddrSpace.h"

--- a/patchAPI/src/Point.C
+++ b/patchAPI/src/Point.C
@@ -29,6 +29,7 @@
  */
 /* Public Interface */
 
+#include <algorithm>
 #include "Point.h"
 #include "PatchMgr.h"
 #include "PatchObject.h"

--- a/proccontrol/src/GeneratorWindows.C
+++ b/proccontrol/src/GeneratorWindows.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "Generator.h"
 #include "GeneratorWindows.h"
 #include "DecoderWindows.h"

--- a/proccontrol/src/arm_process.C
+++ b/proccontrol/src/arm_process.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <string.h>
 #include <iostream>
 #include "proccontrol/src/arm_process.h"

--- a/proccontrol/src/freebsd.C
+++ b/proccontrol/src/freebsd.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "Architecture.h"
 #include "common/h/dyntypes.h"
 #include "PCErrors.h"

--- a/proccontrol/src/generator.C
+++ b/proccontrol/src/generator.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "Generator.h"
 #include "Event.h"
 #include "Mailbox.h"

--- a/proccontrol/src/handler.C
+++ b/proccontrol/src/handler.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "Handler.h"
 #include "PCErrors.h"
 #include "PCProcess.h"

--- a/proccontrol/src/int_thread_db.C
+++ b/proccontrol/src/int_thread_db.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "int_thread_db.h"
 
 

--- a/proccontrol/src/linux.C
+++ b/proccontrol/src/linux.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/syscall.h>

--- a/proccontrol/src/loadLibrary/codegen.C
+++ b/proccontrol/src/loadLibrary/codegen.C
@@ -1,6 +1,7 @@
 // Platform-independent code generation methods; mainly function
 // lookup
 
+#include <algorithm>
 #include "loadLibrary/codegen.h"
 #include <iostream>
 #include "int_process.h"

--- a/proccontrol/src/memcache.C
+++ b/proccontrol/src/memcache.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "memcache.h"
 #include "int_process.h"
 #include <string.h>

--- a/proccontrol/src/ppc_process.C
+++ b/proccontrol/src/ppc_process.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "ppc_process.h"
 #include "common/src/arch-power.h"
 #include <string.h>

--- a/proccontrol/src/process.C
+++ b/proccontrol/src/process.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "dyninstversion.h"
 #include "int_process.h"
 #include "irpc.h"

--- a/proccontrol/src/procpool.C
+++ b/proccontrol/src/procpool.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "procpool.h"
 #include "int_process.h"
 #include "PCErrors.h"

--- a/proccontrol/src/resp.C
+++ b/proccontrol/src/resp.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <utility>
 #include "response.h"
 #include "resp.h"

--- a/proccontrol/src/response.C
+++ b/proccontrol/src/response.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "Event.h"
 
 #include "response.h"

--- a/proccontrol/src/windows_process.C
+++ b/proccontrol/src/windows_process.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "windows_process.h"
 #include "int_process.h"
 #include "GeneratorWindows.h"

--- a/stackwalk/src/aarch64-swk.C
+++ b/stackwalk/src/aarch64-swk.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackwalk/h/swk_errors.h"
 #include "stackwalk/h/procstate.h"
 #include "stackwalk/h/framestepper.h"

--- a/stackwalk/src/analysis_stepper.C
+++ b/stackwalk/src/analysis_stepper.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackwalk/src/analysis_stepper.h"
 #include "dataflowAPI/h/stackanalysis.h"
 #include "stackwalk/h/swk_errors.h"

--- a/stackwalk/src/dbginfo-stepper.C
+++ b/stackwalk/src/dbginfo-stepper.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackwalk/h/framestepper.h"
 #include "stackwalk/h/frame.h"
 #include "stackwalk/h/procstate.h"

--- a/stackwalk/src/framestepper.C
+++ b/stackwalk/src/framestepper.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackwalk/h/framestepper.h"
 #include "stackwalk/h/walker.h"
 #include "stackwalk/h/procstate.h"

--- a/stackwalk/src/linux-swk.C
+++ b/stackwalk/src/linux-swk.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackwalk/h/swk_errors.h"
 #include "stackwalk/h/symlookup.h"
 #include "stackwalk/h/walker.h"

--- a/stackwalk/src/procstate.C
+++ b/stackwalk/src/procstate.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackwalk/h/swk_errors.h"
 #include "stackwalk/h/procstate.h"
 #include "stackwalk/src/libstate.h"

--- a/stackwalk/src/steppergroup.C
+++ b/stackwalk/src/steppergroup.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackwalk/h/steppergroup.h"
 #include "stackwalk/h/framestepper.h"
 #include "stackwalk/h/swk_errors.h"

--- a/stackwalk/src/sw_pcontrol.C
+++ b/stackwalk/src/sw_pcontrol.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackwalk/h/procstate.h"
 #include "stackwalk/h/swk_errors.h"
 #include "stackwalk/h/walker.h"

--- a/stackwalk/src/walker.C
+++ b/stackwalk/src/walker.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackwalk/h/walker.h"
 #include "stackwalk/h/frame.h"
 #include "stackwalk/h/swk_errors.h"

--- a/stackwalk/src/x86-swk.C
+++ b/stackwalk/src/x86-swk.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "stackwalk/h/basetypes.h"
 #include "stackwalk/h/swk_errors.h"
 #include "stackwalk/h/procstate.h"

--- a/symlite/src/SymLite-elf.C
+++ b/symlite/src/SymLite-elf.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "SymLite-elf.h"
 #include "common/src/headers.h"
 #include "unaligned_memory_access.h"

--- a/symtabAPI/src/Aggregate.C
+++ b/symtabAPI/src/Aggregate.C
@@ -27,6 +27,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <algorithm>
 #include "dyntypes.h"
 #include "Annotatable.h"
 

--- a/symtabAPI/src/Archive.C
+++ b/symtabAPI/src/Archive.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "symtabAPI/h/Symtab.h"
 #include "symtabAPI/h/Archive.h"
 #include "symtabAPI/src/Object.h"

--- a/symtabAPI/src/Collections.C
+++ b/symtabAPI/src/Collections.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <stdio.h>
 #include <string>
 

--- a/symtabAPI/src/LineInformation.C
+++ b/symtabAPI/src/LineInformation.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <assert.h>
 #include <filesystem>
 #include <list>

--- a/symtabAPI/src/LinkMap.C
+++ b/symtabAPI/src/LinkMap.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "LinkMap.h"
 #include <iostream>
 

--- a/symtabAPI/src/Object-elf.C
+++ b/symtabAPI/src/Object-elf.C
@@ -33,6 +33,7 @@
  * Object-elf.C: Object class for ELF file format
  ************************************************************************/
 
+#include <algorithm>
 #include "common/src/vgannotations.h"
 #include "unaligned_memory_access.h"
 #include <dwarf_cu_info.h>

--- a/symtabAPI/src/Object-nt.C
+++ b/symtabAPI/src/Object-nt.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include <windows.h>
 #include <cvconst/cvconst.h>
 #include <oleauto.h>

--- a/symtabAPI/src/Object.C
+++ b/symtabAPI/src/Object.C
@@ -30,6 +30,7 @@
 
 // $Id: Object.C,v 1.31 2008/11/03 15:19:25 jaw Exp $
 
+#include <algorithm>
 #include "symutil.h"
 #include "Annotatable.h"
 

--- a/symtabAPI/src/SymtabReader.C
+++ b/symtabAPI/src/SymtabReader.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "symtabAPI/h/SymtabReader.h"
 #include "symtabAPI/h/Symtab.h"
 #include "symtabAPI/h/Symbol.h"

--- a/symtabAPI/src/Type.C
+++ b/symtabAPI/src/Type.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "common/src/vgannotations.h"
 
 #include <string.h>

--- a/symtabAPI/src/Variable.C
+++ b/symtabAPI/src/Variable.C
@@ -30,6 +30,7 @@
 
 // $Id: Object.C,v 1.31 2008/11/03 15:19:25 jaw Exp $
 
+#include <algorithm>
 #include "Annotatable.h"
 
 #include "Symtab.h"

--- a/symtabAPI/src/dwarfWalker.C
+++ b/symtabAPI/src/dwarfWalker.C
@@ -28,6 +28,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <algorithm>
 #include "common/src/vgannotations.h"
 #include "compiler_diagnostics.h"
 #include "dwarfWalker.h"

--- a/symtabAPI/src/emitElfStatic-ppc64.C
+++ b/symtabAPI/src/emitElfStatic-ppc64.C
@@ -33,6 +33,7 @@
  * static executable rewriter
  */
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstdio>
 #include <cassert>

--- a/symtabAPI/src/emitElfStatic-x86.C
+++ b/symtabAPI/src/emitElfStatic-x86.C
@@ -33,6 +33,7 @@
  * static executable rewriter
  */
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstdio>
 #include <cassert>


### PR DESCRIPTION
## Motivation

`CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` are space-separated strings. When
assigned directly to a CMake list variable the entire string becomes a single
list element, so a value like `-march=native -O2` reaches the compiler as one
opaque argument instead of two separate flags. This silently breaks compilation
when any flag requires a following argument (e.g. `-isystem /path`) or when
the compiler rejects the concatenated form.

This surfaces in practice with Clang, which is stricter about multi-flag
strings than GCC.

## Technical Details

Use `separate_arguments(... UNIX_COMMAND ...)` to tokenize `CMAKE_C_FLAGS` and
`CMAKE_CXX_FLAGS` into proper CMake list elements before appending them to the
`DYNINST_C_FLAGS_<BUILD>` / `DYNINST_CXX_FLAGS_<BUILD>` variables:

```cmake
separate_arguments(_dyninst_c_flags   UNIX_COMMAND "${CMAKE_C_FLAGS}")
separate_arguments(_dyninst_cxx_flags UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
```

`UNIX_COMMAND` mode matches POSIX shell word-splitting, which is the correct
semantic for flag strings passed on a compiler command line.

Changed file: `cmake/DyninstOptimization.cmake`

- Add missing "includes" to various headers.

## Test Plan

- [x] Build Dyninst with a multi-flag `CMAKE_C_FLAGS` / `CMAKE_CXX_FLAGS`
  (e.g. `-march=native -O2`) and confirm all flags are passed individually.
- [x] Build with Clang as the C/C++ compiler and verify no flag-parsing errors.
- [x] Confirm existing CMake build types (Release, Debug, RelWithDebInfo) still
  produce correct flag sets.

## Test Result

Builds successfully with Clang when `CMAKE_C_FLAGS` / `CMAKE_CXX_FLAGS`
contain space-separated flags.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.