### PR TITLE
Fix GCC 15 build failure

### DIFF
--- a/dyncompat/assign/list_of.hpp
+++ b/dyncompat/assign/list_of.hpp
@@ -54,10 +54,6 @@ public:
 
   operator std::map<K, V>() const { return std::map<K, V>(values_.begin(), values_.end()); }
 
-  operator std::unordered_map<K, V>() const {
-    return std::unordered_map<K, V>(values_.begin(), values_.end());
-  }
-
   template <typename Map>
   operator Map() const {
     return Map(values_.begin(), values_.end());

--- a/stackwalk/src/framestepper.C
+++ b/stackwalk/src/framestepper.C
@@ -29,6 +29,7 @@
  */
 
 #include <algorithm>
+#include <cstdint>
 #include "stackwalk/h/framestepper.h"
 #include "stackwalk/h/walker.h"
 #include "stackwalk/h/procstate.h"


### PR DESCRIPTION
## Fix GCC 15 build errors

Two independent compilation failures surface when building with GCC 15 (tested with GCC 15.2.1). This PR fixes both.

### 1. Missing `<cstdint>` in `framestepper.C`

GCC 15's libstdc++ no longer transitively includes `<cstdint>` through other standard headers. `stackwalk/src/framestepper.C` uses `uint64_t` without including it directly, producing:

```
error: 'uint64_t' was not declared in this scope
note: 'uint64_t' is defined in header '<cstdint>'; this is probably
      fixable by adding '#include <cstdint>'
```

Fixed by adding the explicit include. (Same class of fix as prior commit `da38f41`, "include stdint.h and cstdint explicitly for newer gcc versions".)

### 2. Eager instantiation of `unordered_map` conversion in `map_builder`

`dyncompat/assign/list_of.hpp`'s `map_builder` declared a non-template conversion operator:

```cpp
operator std::unordered_map<K, V>() const { ... }
```

A non-template conversion operator has its return type instantiated during overload resolution, **even when the target is an unrelated type such as `std::map`**. When `map_list_of(...)` is converted to `std::map<MachRegister, Register>` (in `RegisterConversion-x86.C`), GCC 15 still instantiates `std::unordered_map<MachRegister, Register>`, which requires `std::hash<Dyninst::MachRegister>`. No such specialization exists, so GCC 15's libstdc++ eagerly trips:

```
error: static assertion failed: hash function must be copy constructible
```

Fixed by removing the explicit `unordered_map` operator. The existing generic `template <typename Map> operator Map()` still handles `unordered_map` targets, but as a template it is only instantiated when actually selected — so converting to `std::map` no longer drags in the broken `unordered_map` instantiation.

### Verification

- Full build completes with GCC 15.2.1.
- Confirmed the two real `dyn_hash_map` (= `std::unordered_map`) conversions that *do* use the generic template path — `entryNames_IAPI` and `prefixEntryNames_IAPI` in `common/src/arch-x86.C` — still compile cleanly (their key types are `enum : unsigned int`, which have built-in `std::hash`).
- Running `rocprofiler-systems workflows` in https://github.com/ROCm/rocm-systems/pull/7339.